### PR TITLE
Outsource Security group and fix public IP output

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -255,33 +255,12 @@ resource "azurerm_public_ip" "vm" {
   tags                         = "${var.tags}"
 }
 
-resource "azurerm_network_security_group" "vm" {
-  name                = "${var.vm_hostname}-${coalesce(var.remote_port,module.os.calculated_remote_port)}-nsg"
-  location            = "${azurerm_resource_group.vm.location}"
-  resource_group_name = "${azurerm_resource_group.vm.name}"
-
-  security_rule {
-    name                       = "allow_remote_${coalesce(var.remote_port,module.os.calculated_remote_port)}_in_all"
-    description                = "Allow remote protocol in from all locations"
-    priority                   = 100
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "${coalesce(var.remote_port,module.os.calculated_remote_port)}"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
-
-  tags = "${var.tags}"
-}
-
 resource "azurerm_network_interface" "vm" {
   count                         = "${var.nb_instances}"
   name                          = "nic-${var.vm_hostname}-${count.index}"
   location                      = "${azurerm_resource_group.vm.location}"
   resource_group_name           = "${azurerm_resource_group.vm.name}"
-  network_security_group_id     = "${azurerm_network_security_group.vm.id}"
+  network_security_group_id     = "${var.security_group_id}"
   enable_accelerated_networking = "${var.enable_accelerated_networking}"
 
   ip_configuration {

--- a/main.tf
+++ b/main.tf
@@ -255,6 +255,13 @@ resource "azurerm_public_ip" "vm" {
   tags                         = "${var.tags}"
 }
 
+data "azurerm_public_ip" "vm" {
+  count               = "${var.nb_public_ip}"
+  name                = "${var.vm_hostname}-${count.index}-publicIP"
+  location            = "${var.location}"
+  resource_group_name = "${azurerm_resource_group.vm.name}"
+}
+
 resource "azurerm_network_interface" "vm" {
   count                         = "${var.nb_instances}"
   name                          = "nic-${var.vm_hostname}-${count.index}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,11 +3,6 @@ output "vm_ids" {
   value       = "${concat(azurerm_virtual_machine.vm-windows.*.id,azurerm_virtual_machine.vm-windows-with-datadisk.*.id, azurerm_virtual_machine.vm-linux.*.id,azurerm_virtual_machine.vm-linux-with-datadisk.*.id)}"
 }
 
-output "network_security_group_id" {
-  description = "id of the security group provisioned"
-  value       = "${azurerm_network_security_group.vm.id}"
-}
-
 output "network_interface_ids" {
   description = "ids of the vm nics provisoned."
   value       = "${azurerm_network_interface.vm.*.id}"
@@ -25,7 +20,7 @@ output "public_ip_id" {
 
 output "public_ip_address" {
   description = "The actual ip address allocated for the resource."
-  value       = "${azurerm_public_ip.vm.*.ip_address}"
+  value       = "${data.azurerm_public_ip.vm.*.ip_address}"
 }
 
 output "public_ip_dns_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,10 @@ variable "vnet_subnet_id" {
   description = "The subnet id of the virtual network where the virtual machines will reside."
 }
 
+variable "security_group_id" {
+  description = "The security group id to be associated with the network interface. Subnet-NSG-Association must be done outside this module"
+}
+
 variable "public_ip_dns" {
   description = "Optional globally unique per datacenter region domain name label to apply to each public ip address. e.g. thisvar.varlocation.cloudapp.azure.com where you specify only thisvar here. This is an array of names which will pair up sequentially to the number of public ips defined in var.nb_public_ip. One name or empty string is required for every public ip. If no public ip is desired, then set this to an array with a single empty string."
   default     = [""]


### PR DESCRIPTION
* Security group creation resides now outside of the compute module. Create your NSGs with github.com/Azure/terraform-azurerm-network-security-group
* the attribute `ip_address` only exists on the data type `azurerm_public_ip`