### PR TITLE
Auto Static IP Assignment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -198,7 +198,8 @@ resource "azurerm_network_interface" "vm" {
   ip_configuration {
     name                          = "ipconfig${count.index}"
     subnet_id                     = var.vnet_subnet_id
-    private_ip_address_allocation = "Dynamic"
+    private_ip_address            = var.auto_assign_static_ip ? cidrhost(var.vnet_subnet_prefix, count.index+10) : ""
+    private_ip_address_allocation = var.auto_assign_static_ip ? "Static" : "Dynamic"
     public_ip_address_id          = length(azurerm_public_ip.vm.*.id) > 0 ? element(concat(azurerm_public_ip.vm.*.id, [""]), count.index) : ""
   }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -35,4 +35,3 @@ output "availability_set_id" {
   description = "id of the availability set where the vms are provisioned."
   value       = azurerm_availability_set.vm.id
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,12 @@ variable "vnet_subnet_id" {
   description = "The subnet id of the virtual network where the virtual machines will reside."
 }
 
+variable "vnet_subnet_prefix" {
+  description = "The subnet id of the virtual network where the virtual machines will reside."
+  # backwards compatibility
+  default = ""
+}
+
 variable "security_group_id" {
   description = "The security group id to be associated with the network interface. Subnet-NSG-Association must be done outside this module"
 }
@@ -173,3 +179,8 @@ variable "enable_accelerated_networking" {
   default     = "false"
 }
 
+variable "auto_assign_static_ip" {
+  type        = bool
+  description = "Automatically assigns a static ip address according to the instance number starting at 10. (Example: count: 0, vnet_subnet_prefix 10.1.0.0/24 --> 10.1.0.10)"
+  default     = false
+}


### PR DESCRIPTION
Add functionality to enable auto-static-ip-assignment using the auto_assign_static_ip variable.

> Automatically assigns a static ip address according to the instance number starting at 10.